### PR TITLE
Disable doctests for GHC >= 9.2

### DIFF
--- a/bsb-http-chunked.cabal
+++ b/bsb-http-chunked.cabal
@@ -66,6 +66,9 @@ test-suite doctests
                  , doctest >= 0.8
   ghc-options: -Wall
   type: exitcode-stdio-1.0
+  if impl(ghc >= 9.2)
+    -- https://github.com/sjakobi/bsb-http-chunked/issues/38
+    buildable: False
 
 benchmark bench
   hs-source-dirs: bench


### PR DESCRIPTION
Closes #38.