### PR TITLE
Fix doctests for compatibility with GHC 9.2

### DIFF
--- a/bsb-http-chunked.cabal
+++ b/bsb-http-chunked.cabal
@@ -66,9 +66,6 @@ test-suite doctests
                  , doctest >= 0.8
   ghc-options: -Wall
   type: exitcode-stdio-1.0
-  if impl(ghc >= 9.2)
-    -- https://github.com/sjakobi/bsb-http-chunked/issues/38
-    buildable: False
 
 benchmark bench
   hs-source-dirs: bench

--- a/tests/Doctests.hs
+++ b/tests/Doctests.hs
@@ -1,6 +1,6 @@
 import Test.DocTest
 
 main :: IO ()
-main = doctest ["-isrc", "Data/ByteString/Builder/HTTP/Chunked.hs"]
+main = doctest ["-isrc", "-XHaskell2010", "Data/ByteString/Builder/HTTP/Chunked.hs"]
 
 


### PR DESCRIPTION
Based on advice from @sol in
https://github.com/sol/doctest/issues/326#issuecomment-997369942.