### PR TITLE
Allow bytestring-0.12, use PartialTypeSignatures

### DIFF
--- a/Data/ByteString/Builder/HTTP/Chunked.hs
+++ b/Data/ByteString/Builder/HTTP/Chunked.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, MagicHash, OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns, MagicHash, OverloadedStrings, ScopedTypeVariables, PartialTypeSignatures #-}
 -- | HTTP/1.1 chunked transfer encoding as defined
 -- in [RFC 7230 Section 4.1](https://tools.ietf.org/html/rfc7230#section-4.1)
 

--- a/bsb-http-chunked.cabal
+++ b/bsb-http-chunked.cabal
@@ -39,7 +39,7 @@ Source-repository head
 Library
   exposed-modules:   Data.ByteString.Builder.HTTP.Chunked
   build-depends:     base >= 4.8 && < 5,
-                     bytestring >= 0.10.2 && < 0.12
+                     bytestring >= 0.10.2 && < 0.13
   ghc-options:       -Wall -O2
   if impl(ghc >= 8.0)
     ghc-options:     -Wcompat


### PR DESCRIPTION
Fix #47.

CI config not updated since haskell-ci isn't supporting GHC 9.8 yet.
